### PR TITLE
Edge2AI Updates

### DIFF
--- a/setup/terraform/.env.template
+++ b/setup/terraform/.env.template
@@ -64,7 +64,7 @@ export TF_VAR_azure_tenant_id=
 #############################################
 
 # Other options
-export TF_VAR_ssh_username=centos
+export TF_VAR_ssh_username=cloud-user
 export TF_VAR_ssh_password=Supersecret1
 export TF_VAR_deploy_cdsw_model=true
 
@@ -128,24 +128,23 @@ if [[ "${TF_VAR_base_ami:-}" == "" ]]; then
     esac
   elif [[ "${TF_VAR_os_type:-centos8}" == "centos8" ]]; then
     case "$TF_VAR_aws_region" in
-      # Image name: " (SupportedImages) - CentOS 8 x86_64 - LATEST - 20240610-f399b70b-09d8-4df4-ba78-bc1813b4b257"
-      "ap-northeast-1") TF_VAR_base_ami=ami-0b24aab129d5967d4 ;;
-      "ap-northeast-2") TF_VAR_base_ami=ami-0e6731506e259823a ;;
-      "ap-northeast-3") TF_VAR_base_ami=ami-00be0e28a4622e895 ;;
-      "ap-south-1")     TF_VAR_base_ami=ami-050195c14f073e05a ;;
-      "ap-southeast-1") TF_VAR_base_ami=ami-0baea92ad7ae0a5c4 ;;
-      "ap-southeast-2") TF_VAR_base_ami=ami-0ce6b490754bfb92c ;;
-      "ca-central-1")   TF_VAR_base_ami=ami-01cd46386faf76b39 ;;
-      "eu-central-1")   TF_VAR_base_ami=ami-0483096b525b7f4b9 ;;
-      "eu-north-1")     TF_VAR_base_ami=ami-03a454a1e2f761ad7 ;;
-      "eu-west-1")      TF_VAR_base_ami=ami-09f9676371a847539 ;;
-      "eu-west-2")      TF_VAR_base_ami=ami-06cf0198b442149df ;;
-      "eu-west-3")      TF_VAR_base_ami=ami-05119d1c8cefc3c37 ;;
-      "sa-east-1")      TF_VAR_base_ami=ami-000bae4ea08633407 ;;
-      "us-east-1")      TF_VAR_base_ami=ami-0dee6253de8d823eb ;;
-      "us-east-2")      TF_VAR_base_ami=ami-0edfb0bedcbbe3576 ;;
-      "us-west-1")      TF_VAR_base_ami=ami-08ef93ce1d6924452 ;;
-      "us-west-2")      TF_VAR_base_ami=ami-031f9dbf46a9fab33 ;;
+      # Image name: " CentOS Stream 8 (x86_64) - CentOS-Stream-ec2-8-20220913.0-20230101.2.x86_64-ca49f421-e5ed-4bb8-86a9-4b59878819e1-ami-0859d3b3fb57013df.4"
+      "ap-northeast-1") TF_VAR_base_ami=ami-0f645e55f2fd43967 ;;
+      "ap-northeast-2") TF_VAR_base_ami=ami-053171b6ca2943bce ;;
+      "ap-northeast-3") TF_VAR_base_ami=ami-0e25efc0de2b87f00 ;;
+      "ap-south-1")     TF_VAR_base_ami=ami-0482755818a2ca044 ;;
+      "ap-southeast-1") TF_VAR_base_ami=ami-034b54b016f6c70cd ;;
+      "ap-southeast-2") TF_VAR_base_ami=ami-01bdb48fb60b79ddc ;;
+      "ca-central-1")   TF_VAR_base_ami=ami-06f398c1cb1c0c616 ;;
+      "eu-central-1")   TF_VAR_base_ami=ami-03a077d7c4e72ea87 ;;
+      "eu-north-1")     TF_VAR_base_ami=ami-0483db98bd5d1c5d1 ;;
+      "eu-west-1")      TF_VAR_base_ami=ami-09159a5fef8131781 ;;
+      "eu-west-2")      TF_VAR_base_ami=ami-016a42ee455024d5a ;;
+      "eu-west-3")      TF_VAR_base_ami=ami-0c76fbeca47e5196b ;;
+      "us-east-1")      TF_VAR_base_ami=ami-05f2b469e504202f7 ;;
+      "us-east-2")      TF_VAR_base_ami=ami-0af29b92a1457bf87 ;;
+      "us-west-1")      TF_VAR_base_ami=ami-043114a99aad01354 ;;
+      "us-west-2")      TF_VAR_base_ami=ami-0aea155a6569f258a ;;
     esac
   else
     case "$TF_VAR_aws_region" in

--- a/setup/terraform/packer.json
+++ b/setup/terraform/packer.json
@@ -15,7 +15,7 @@
         {
           "device_name": "/dev/sda1",
           "volume_size": 100,
-          "volume_type": "gp2",
+          "volume_type": "gp3",
           "delete_on_termination": true
         }
       ],

--- a/setup/terraform/providers/aws/instances.tf
+++ b/setup/terraform/providers/aws/instances.tf
@@ -22,14 +22,14 @@ resource "aws_instance" "cluster" {
   }
 
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = "200"
     delete_on_termination = true
   }
 
   ebs_block_device {
     device_name           = "/dev/sdf"
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = "200"
   }
 
@@ -85,7 +85,7 @@ resource "aws_instance" "web" {
   ]
 
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = "20"
     delete_on_termination = true
   }
@@ -138,7 +138,7 @@ resource "aws_instance" "ipa" {
   ]
 
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = "20"
     delete_on_termination = true
   }
@@ -201,7 +201,7 @@ resource "aws_instance" "ecs" {
   }
 
   root_block_device {
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     volume_size           = "500"
     delete_on_termination = true
   }

--- a/setup/terraform/resources/stack.cdp716p.sh
+++ b/setup/terraform/resources/stack.cdp716p.sh
@@ -13,7 +13,7 @@ ENABLE_TLS=no
 JAVA_PACKAGE_NAME=java-1.8.0-openjdk-devel
 
 ##### Maven binary
-MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
 
 #####  CM
 CM_VERSION=7.3.1

--- a/setup/terraform/resources/stack.cdp717-trial.sh
+++ b/setup/terraform/resources/stack.cdp717-trial.sh
@@ -13,7 +13,7 @@ ENABLE_TLS=no
 JAVA_PACKAGE_NAME=java-11-openjdk-devel
 
 ##### Maven binary
-MAVEN_BINARY_URL=https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz
+MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
 
 #####  CM
 CM_VERSION=7.4.4

--- a/setup/terraform/resources/stack.cdp717p.sh
+++ b/setup/terraform/resources/stack.cdp717p.sh
@@ -13,7 +13,7 @@ ENABLE_TLS=no
 JAVA_PACKAGE_NAME=java-11-openjdk-devel
 
 ##### Maven binary
-MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
 
 #####  CM
 CM_VERSION=7.6.1

--- a/setup/terraform/resources/stack.cdp718p.sh
+++ b/setup/terraform/resources/stack.cdp718p.sh
@@ -13,7 +13,7 @@ ENABLE_TLS=no
 JAVA_PACKAGE_NAME=java-11-openjdk-devel
 
 ##### Maven binary
-MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
 
 #####  CM
 CM_VERSION=7.7.1

--- a/setup/terraform/resources/stack.cdp719p.sh
+++ b/setup/terraform/resources/stack.cdp719p.sh
@@ -14,7 +14,7 @@ JAVA_PACKAGE_NAME=java-11-openjdk-devel
 OPENJDK_VERSION=17.0.2
 
 ##### Maven binary
-MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
 
 #####  CM
 CM_VERSION=7.11.3.9

--- a/setup/terraform/resources/stack.cdp731p.sh
+++ b/setup/terraform/resources/stack.cdp731p.sh
@@ -14,7 +14,7 @@ JAVA_PACKAGE_NAME=java-11-openjdk-devel
 OPENJDK_VERSION=17.0.2
 
 ##### Maven binary
-MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+MAVEN_BINARY_URL=https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
 
 #####  CM
 CM_VERSION=7.13.1.0


### PR DESCRIPTION
Updated default centos image to free image provided by AWS and updated default ssh user
https://aws.amazon.com/marketplace/pp/prodview-36nhetkhe3fmk?sr=0-2&ref_=beagle&applicationId=AWSMPContessa

Updated AWS EBS volumes to use gp3 instead of gp2

Updated stack files to use valid Maven 3.9.11 repo instead of deprecated 3.9.9 repo
https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
